### PR TITLE
Ошибка при заполнении тегов у фотографии

### DIFF
--- a/source/Yandex/Fotki/Api/Photo.php
+++ b/source/Yandex/Fotki/Api/Photo.php
@@ -222,9 +222,9 @@ class Photo extends \Yandex\Fotki\ApiAbstract
     public function setTags($tags)
     {
         if(is_array($tags) || $tags instanceof \ArrayAccess){
-		    $this->_tags = implode(', ', $tags);
-	    }else{
-		    $this->_tags = (string)$tags;
+	    	$this->_tags = implode(', ', $tags);
+    	}else{
+	    	$this->_tags = (string)$tags;
 	    }
         return $this;
     }

--- a/source/Yandex/Fotki/Api/Photo.php
+++ b/source/Yandex/Fotki/Api/Photo.php
@@ -222,10 +222,10 @@ class Photo extends \Yandex\Fotki\ApiAbstract
     public function setTags($tags)
     {
         if(is_array($tags) || $tags instanceof \ArrayAccess){
-	    	$this->_tags = implode(', ', $tags);
-    	}else{
-	    	$this->_tags = (string)$tags;
-	    }
+            $this->_tags = implode(', ', $tags);
+        }else{
+            $this->_tags = (string)$tags;
+        }
         return $this;
     }
 

--- a/source/Yandex/Fotki/Api/Photo.php
+++ b/source/Yandex/Fotki/Api/Photo.php
@@ -221,7 +221,11 @@ class Photo extends \Yandex\Fotki\ApiAbstract
      */
     public function setTags($tags)
     {
-        $this->_tags = (string)$tags;
+        if(is_array($tags) || $tags instanceof \ArrayAccess){
+		    $this->_tags = implode(', ', $tags);
+	    }else{
+		    $this->_tags = (string)$tags;
+	    }
         return $this;
     }
 


### PR DESCRIPTION
Так как JSON API отдает теги фотографии, как массив данных, то в этом месте выдается NOTICE из-за неправильного приведения типов (array -> string)
